### PR TITLE
fix: unblock Pages deploy (dead self-hosted runner) + remove empty link tag

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/index.html
+++ b/index.html
@@ -12,8 +12,6 @@
     <meta property="og:url" content="https://fabriziosalmi.github.io/enjoy/">
     <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="fonts.css">
-    <link
-        rel="stylesheet">
     <style>
         :root {
             --bg: #030305;


### PR DESCRIPTION
## The real problem
This repo **already self-hosts its fonts** (`fonts.css` + `fonts/` with Space Grotesk and JetBrains Mono woff2). But the live site still loads Google Fonts — because **nothing has deployed since April**.

Every `deploy-pages` run is `cancelled`, including the one for current `main`:

```
runs-on: [self-hosted, runner-02]
```

That runner no longer answers, so the job queues and gets cancelled. `fabriziosalmi.github.io/enjoy/fonts.css` returns **404** while `main` has had it for months.

## Changes
- **`deploy-pages.yml`** — `runs-on` → `ubuntu-latest` (same fix already applied elsewhere in your repos). **This is what actually ships the pending font change**, plus everything else merged since April.
- **`index.html`** — removed a leftover `<link rel="stylesheet">` with **no `href`**, left behind when the Google Fonts URL was stripped out.

After merge, it's worth confirming the deploy goes green and `/enjoy/fonts.css` starts returning 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)