### PR TITLE
ci: move every workflow off the dead self-hosted runner

### DIFF
--- a/.github/workflows/RUNNER_SECURITY.md
+++ b/.github/workflows/RUNNER_SECURITY.md
@@ -1,5 +1,16 @@
 # 🛡️ Runner Security Policy
 
+> **Status (July 2026): this repository no longer uses a self-hosted runner.**
+> Every workflow now runs on `ubuntu-latest`. The `runner-02` host stopped
+> answering and every run queued against it was cancelled, which silently froze
+> the site and all automation from March until July 2026 — nothing deployed and
+> no scheduled job ran, without any failure notification.
+>
+> The policy below is kept because its reasoning still holds: **if a self-hosted
+> runner is ever reintroduced, workflows that process untrusted external input
+> must stay on `ubuntu-latest`.** Treat the table as the rule to re-apply, not as
+> a description of the current setup.
+
 ## Self-Hosted Runner Configuration
 
 ### Label Setup

--- a/.github/workflows/celebrate-milestones.yml
+++ b/.github/workflows/celebrate-milestones.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   check-milestones:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       
@@ -93,7 +93,7 @@ jobs:
   celebrate-level-up:
     needs: check-milestones
     if: needs.check-milestones.outputs.level_up == 'true'
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       
@@ -153,7 +153,7 @@ jobs:
   celebrate-achievement:
     needs: check-milestones
     if: needs.check-milestones.outputs.new_achievement == 'true'
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       
@@ -206,7 +206,7 @@ jobs:
   celebrate-players:
     needs: check-milestones
     if: needs.check-milestones.outputs.player_milestone != 'false'
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       
@@ -256,7 +256,7 @@ jobs:
 
   generate-hearts:
     needs: check-milestones
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/daily-maintenance.yml
+++ b/.github/workflows/daily-maintenance.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   maintenance:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/dynamic-header.yml
+++ b/.github/workflows/dynamic-header.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   update-header:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     
     steps:
       - name: Checkout

--- a/.github/workflows/generate-art.yml
+++ b/.github/workflows/generate-art.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   generate-art:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/generate-metrics.yml
+++ b/.github/workflows/generate-metrics.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   generate-metrics:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/guardian-angel.yml
+++ b/.github/workflows/guardian-angel.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-inactive-players:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   health-check:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     # Only run if workflow_run was successful (or other triggers)
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - name: 🧹 Mark and close stale issues
         uses: actions/stale@v9

--- a/.github/workflows/sync-repo-stats.yml
+++ b/.github/workflows/sync-repo-stats.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   sync-stats:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/time-capsule.yml
+++ b/.github/workflows/time-capsule.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   time-capsule:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/track-entropy.yml
+++ b/.github/workflows/track-entropy.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   measure-entropy:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/track-karma.yml
+++ b/.github/workflows/track-karma.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   track-karma:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   translate:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       

--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   update-badges:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:

--- a/.github/workflows/update-bounty-board.yml
+++ b/.github/workflows/update-bounty-board.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   update-bounty-board:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   update-leaderboard:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-readme-stats.yml
+++ b/.github/workflows/update-readme-stats.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update-stats:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     # Only run if workflow_run was successful (or other triggers)
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   weekly-report:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/write-story.yml
+++ b/.github/workflows/write-story.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   write-story:
-    runs-on: [self-hosted, runner-02]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       


### PR DESCRIPTION
## What happened
`runner-02` stopped answering. Every run queued against it was **cancelled**, so from **March to July 2026 nothing in this repository ran** — no deploys, no scheduled automation. And because cancelled runs aren't failures, **nothing ever notified you**: it just looked quiet.

This was found while fixing the Google Fonts leak: the fonts were *already* self-hosted in `main`, yet the live site still loaded them from Google. The code was fine — it had simply never shipped.

## Changes
- **19 workflows**: `runs-on: [self-hosted, runner-02]` → `ubuntu-latest`.
  I checked what each one actually does first: they only use standard actions and toolchains (`checkout`, `setup-node`, `git`, `gh api`). **None needed a local machine** — the self-hosted label bought nothing here.
- **`RUNNER_SECURITY.md`**: added a status note at the top and **kept the policy**, because its rule still holds if a self-hosted runner ever comes back — workflows processing untrusted external input must stay on `ubuntu-latest`.

`deploy-pages.yml` was migrated separately earlier; **its first run after the fix succeeded**, which is what confirmed the diagnosis.

> Note: this repo is public, so GitHub-hosted minutes are free and unmetered — there is no cost trade-off in this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)